### PR TITLE
fix personnel.create

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ ccure.personnel.update(5001, {"Text14": "new text here", "MiddleName": "Shaquill
 
 ```python
 from acslib import CcureAPI
-from acslib.ccure.types import PersonnelCreateData as pcd
+from acslib.ccure.data_models import PersonnelCreateData as pcd
 
 ccure = CcureAPI()
 new_person_data = pcd(FirstName="Kenny", LastName="Smith", Text1="001132808")
@@ -190,7 +190,8 @@ response = ccure.clearance_item.update(ObjectType.DOOR.complete, 5000, update_da
 
 ```python
 from acslib import CcureAPI
-from acslib.ccure.types import ClearanceItemCreateData, ObjectType
+from acslib.ccure.data_models import ClearanceItemCreateData
+from acslib.ccure.types import ObjectType
 
 # create a new elevator
 ccure = CcureAPI()

--- a/acslib/ccure/crud.py
+++ b/acslib/ccure/crud.py
@@ -77,7 +77,13 @@ class CcurePersonnel(CcureACS):
         create_data must contain a 'LastName' property.
         """
         create_data_dict = create_data.model_dump()
-        request_data = create_data_dict | {"ClassType": self.type}
+        property_names = list(create_data_dict)
+        property_values = list(create_data_dict.values())
+        request_data = {
+            "Type": self.type,
+            "PropertyNames": property_names,
+            "PropertyValues": property_values,
+        }
         return super().create(request_data=request_data)
 
     def delete(self, personnel_id: int) -> ACSRequestResponse:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "acslib"
-version = "0.1.9"
+version = "0.1.10"
 authors = [
     { name="Jeremy Gibson", email="jmgibso3@ncsu.edu" },
     { name="Luc Sanchez", email="lgsanche@ncsu.edu" },


### PR DESCRIPTION
The `ccure.personnel.create` method was erroring out. This fixes it with two changes:
- the "ClassType" field is now "Type"
- `request_data` now uses "PropertyNames" and "PropertyValues" arrays instead of k/v pairs for each property