### PR TITLE
set large default page size

### DIFF
--- a/acslib/ccure/crud.py
+++ b/acslib/ccure/crud.py
@@ -109,7 +109,7 @@ class CcureClearance(CcureACS):
         self,
         terms: Optional[list] = None,
         search_filter: Optional[ClearanceFilter] = None,
-        page_size: Optional[int] = None,
+        page_size: Optional[int] = 100000,
         page_number: int = 1,
         timeout: Number = 0,
         search_options: Optional[dict] = None,


### PR DESCRIPTION
Setting `page_size` to None in call to C9K results in a default page size of 100 to take effect. This change effectively removes the page size limit by increasing it to a very high number.