### PR TITLE
add reduce to ACSRequestException

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         language_version: python3.10
         exclude: migrations
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
+    rev: 1.8.6
     hooks:
       - id: bandit
         args: [ "-c", "pyproject.toml" ]

--- a/acslib/base/connection.py
+++ b/acslib/base/connection.py
@@ -1,12 +1,13 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from numbers import Number
 from typing import Any, Optional
 
 import requests
+from requests import structures
 from pydantic import BaseModel
 
 from acslib.base import status
+from acslib.base.config import ACSConfig
 
 
 class ACSConnectionException(Exception):
@@ -26,6 +27,9 @@ class ACSRequestException(Exception):
 
     def __str__(self):
         return f"{self.exception_name}: {self.status_code} {self.message}"
+
+    def __reduce__(self):
+        return (ACSRequestException, (self.status_code, self.message))
 
 
 class ACSNotImplementedException(ACSRequestException):
@@ -47,7 +51,7 @@ class ACSRequestResponse:
     """Successful queries from handle_request return this type of object"""
 
     def __init__(
-        self, status_code: int, json: Any, headers: requests.structures.CaseInsensitiveDict
+        self, status_code: int, json: Any, headers: structures.CaseInsensitiveDict
     ):
         self.status_code = status_code
         self.json = json
@@ -80,7 +84,7 @@ class ACSConnection(ABC):
     }
 
     def __init__(self, **kwargs):
-        self.config = kwargs.get("config")
+        self.config: ACSConfig = kwargs["config"]
         self.timeout = kwargs.get("timeout", self.config.timeout)
         self.response = None
 
@@ -98,7 +102,7 @@ class ACSConnection(ABC):
         raise ACSConnectionException(f"Invalid request method: {requests_method}")
 
     def request(
-        self, requests_method: ACSRequestMethod, request_data: ACSRequestData, timeout: Number
+        self, requests_method: ACSRequestMethod, request_data: ACSRequestData, timeout: float
     ) -> ACSRequestResponse:
         """
         Process requests to remote servers.
@@ -160,13 +164,13 @@ class ACSConnection(ABC):
         except requests.ConnectionError:
             # A Connection error occurred.
             raise ACSRequestException(
-                status_code=status.HTTP_400_BAD_REQUEST,
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 log_message="Could not connect to the remote host",
             )
         except requests.RequestException:
             # There was an ambiguous exception that occurred while handling your request.
             raise ACSRequestException(
-                status_code=status.HTTP_400_BAD_REQUEST,
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 log_message="An exception occurred while handling this request",
             )
         if response.status_code in range(200, 300):
@@ -175,6 +179,6 @@ class ACSConnection(ABC):
             )
         if response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR:
             raise ACSRequestException(
-                status_code=status.HTTP_400_BAD_REQUEST, log_message=response.text
+                status_code=status.HTTP_502_BAD_GATEWAY, log_message=response.text
             )
         raise ACSRequestException(status_code=response.status_code, log_message=response.text)

--- a/acslib/base/connection.py
+++ b/acslib/base/connection.py
@@ -50,9 +50,7 @@ class ACSRequestMethod(Enum):
 class ACSRequestResponse:
     """Successful queries from handle_request return this type of object"""
 
-    def __init__(
-        self, status_code: int, json: Any, headers: structures.CaseInsensitiveDict
-    ):
+    def __init__(self, status_code: int, json: Any, headers: structures.CaseInsensitiveDict):
         self.status_code = status_code
         self.json = json
         self.headers = headers

--- a/acslib/ccure/base.py
+++ b/acslib/ccure/base.py
@@ -1,4 +1,3 @@
-from numbers import Number
 from typing import Optional, Any
 
 from acslib.base import AccessControlSystem, ACSRequestData, ACSRequestResponse, ACSRequestException
@@ -28,7 +27,7 @@ class CcureACS(AccessControlSystem):
         search_filter: Optional[CcureFilter] = None,
         page_size: Optional[int] = None,
         page_number: int = 1,
-        timeout: Number = 0,
+        timeout: float = 0,
         search_options: Optional[dict] = None,
         where_clause: Optional[str] = None,
     ) -> int | list:

--- a/acslib/ccure/config.py
+++ b/acslib/ccure/config.py
@@ -66,7 +66,8 @@ class CcureConfig(ACSConfig):
 class CcureConfigFactory:
     def __new__(cls, *args, **kwargs) -> CcureConfig:
         """
-        CcuureConfigFactory returns a CcureConfig instance with the correct endpoints for the requested API version.
+        CcureConfigFactory returns a CcureConfig instance with the correct endpoints
+        for the requested API version.
         The default api version is 2.
         :param args:
         :param kwargs:

--- a/acslib/ccure/connection.py
+++ b/acslib/ccure/connection.py
@@ -1,5 +1,4 @@
 import logging
-from numbers import Number
 from typing import Optional
 
 from acslib.base import (
@@ -111,7 +110,7 @@ class CcureConnection(ACSConnection):
         self,
         requests_method: ACSRequestMethod,
         request_data: ACSRequestData,
-        timeout: Optional[Number] = 0,
+        timeout: Optional[float] = 0,
         request_attempts: int = 2,
     ) -> ACSRequestResponse:
         """

--- a/acslib/ccure/crud.py
+++ b/acslib/ccure/crud.py
@@ -1,5 +1,4 @@
-from numbers import Number
-from typing import Any, Optional, Literal
+from typing import Any, Optional
 
 from acslib.base import ACSRequestResponse
 from acslib.base.connection import ACSNotImplementedException
@@ -33,7 +32,7 @@ class CcurePersonnel(CcureACS):
         search_filter: Optional[PersonnelFilter] = None,
         page_size: Optional[int] = None,
         page_number: int = 1,
-        timeout: Number = 0,
+        timeout: float = 0,
         search_options: Optional[dict] = None,
         where_clause: Optional[str] = None,
     ) -> list:
@@ -113,7 +112,7 @@ class CcureClearance(CcureACS):
         search_filter: Optional[ClearanceFilter] = None,
         page_size: Optional[int] = None,
         page_number: int = 1,
-        timeout: Number = 0,
+        timeout: float = 0,
         search_options: Optional[dict] = None,
         where_clause: Optional[str] = None,
     ) -> list:
@@ -256,7 +255,7 @@ class CcureClearanceItem(CcureACS):
         search_filter: Optional[ClearanceItemFilter] = None,
         page_size: Optional[int] = None,
         page_number: int = 1,
-        timeout: Number = 0,
+        timeout: float = 0,
         search_options: Optional[dict] = None,
         where_clause: Optional[str] = None,
     ) -> list:
@@ -353,7 +352,7 @@ class CcureGroup(CcureACS):
         search_filter: Optional[GroupFilter] = None,
         page_size: Optional[int] = None,
         page_number: int = 1,
-        timeout: Number = 0,
+        timeout: float = 0,
         search_options: Optional[dict] = None,
         where_clause: Optional[str] = None,
     ) -> list:
@@ -408,7 +407,7 @@ class CcureGroupMember(CcureACS):
         search_filter: Optional[GroupMemberFilter] = None,
         page_size: Optional[int] = None,
         page_number: int = 1,
-        timeout: Number = 0,
+        timeout: float = 0,
         search_options: Optional[dict] = None,
         where_clause: Optional[str] = None,
     ) -> list:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "pyupgrade>=2.29.1, <3.0.0",
     "flit>=3.8.0, <4.0.0",
     "Faker>=20.0.0, <21.0.0",
+    "packaging>=24.0.0, <27.0.0"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "acslib"
-version = "0.1.16"
+version = "0.1.17"
 authors = [
     { name="Jeremy Gibson", email="jmgibso3@ncsu.edu" },
     { name="Luc Sanchez", email="lgsanche@ncsu.edu" },

--- a/requirements/base/base.txt
+++ b/requirements/base/base.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements/base/base.txt pyproject.toml
 #
+--extra-index-url https://pypi.ehps.ncsu.edu/
+
 annotated-types==0.6.0
     # via pydantic
 certifi==2023.7.22

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -10,7 +10,7 @@ attrs==23.1.0
     # via pytest
 babel==2.13.1
     # via mkdocs-material
-bandit[toml]==1.7.5
+bandit[toml]==1.9.4
     # via acslib (pyproject.toml)
 black==23.11.0
     # via acslib (pyproject.toml)
@@ -54,10 +54,6 @@ flit-core==3.9.0
     # via flit
 ghp-import==2.1.0
     # via mkdocs
-gitdb==4.0.11
-    # via gitpython
-gitpython==3.1.40
-    # via bandit
 griffe==0.38.0
     # via mkdocstrings-python
 identify==2.5.31
@@ -119,8 +115,9 @@ nodeenv==1.8.0
     # via pre-commit
 oracledb==1.4.1
     # via sat-utils
-packaging==23.2
+packaging==26.0
     # via
+    #   acslib (pyproject.toml)
     #   black
     #   mkdocs
     #   pytest
@@ -204,8 +201,6 @@ six==1.16.0
     # via python-dateutil
 slack-sdk==3.23.0
     # via sat-utils
-smmap==5.0.1
-    # via gitdb
 stevedore==5.1.0
     # via bandit
 tokenize-rt==4.2.1

--- a/requirements/dev/dev.txt
+++ b/requirements/dev/dev.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --extra=dev --output-file=requirements/dev/dev.txt pyproject.toml
 #
+--extra-index-url https://pypi.ehps.ncsu.edu/
+
 annotated-types==0.6.0
     # via pydantic
 attrs==23.1.0


### PR DESCRIPTION
- Request exceptions were breaking in automations if they needed to be unpickled by celery. This fixes that problem, so that the automation will get the correct ACSRequestException instead of a celery error. 
- change some http response codes for `requests` errors
- fix a compatibility issue with the `packaging` library
- a lot of cleanup, mostly about typing