### PR TITLE
use different endpoint for personnel searches

### DIFF
--- a/acslib/ccure/base.py
+++ b/acslib/ccure/base.py
@@ -2,7 +2,7 @@ from typing import Optional, Any
 
 from acslib.base import AccessControlSystem, ACSRequestData, ACSRequestResponse, ACSRequestException
 from acslib.ccure.connection import CcureConnection, ACSRequestMethod
-from acslib.ccure.filters import CcureFilter, NFUZZ
+from acslib.ccure.filters import CcureFilter, NFUZZ, PersonnelFilter
 
 
 class CcureACS(AccessControlSystem):
@@ -65,6 +65,48 @@ class CcureACS(AccessControlSystem):
             timeout=timeout,
         )
         return response.json
+
+    def search_personnel(
+        self,
+        search_filter: PersonnelFilter,
+        sort_column: str,
+        terms: Optional[list] = None,
+        page_size: Optional[int] = None,
+        page_number: int = 1,
+        timeout: float = 0,
+        search_options: Optional[dict] = None,
+        where_clause: Optional[str] = None,
+        where_arg_list: Optional[list[str]] = None,
+    ) -> list[dict]:
+        """
+        Personnel requires a separate endpoint to support searching with special characters
+        """
+        if search_filter is None and not where_clause:
+            raise ACSRequestException(400, "A search filter or where clause is required.")
+        if page_size is None:
+            page_size = self.config.page_size
+        if not where_clause or not where_arg_list:
+            where_clause, where_arg_list = search_filter.filter(terms or [])
+        request_json = {
+            "pageSize": page_size,
+            "pageNumber": page_number,
+            "propertyList": search_filter.display_properties,
+            "explicitPropertyList": search_filter.explicit_property_list,
+            "sortColumnName": sort_column,
+            "whereClause": where_clause,
+            "whereArgList": where_arg_list,
+        } | (search_options or {})
+        response = self.connection.request(
+            ACSRequestMethod.POST,
+            request_data=ACSRequestData(
+                url=self.connection.config.base_url
+                + self.connection.config.endpoints.PERSONNEL_SEARCH,
+                request_json=request_json,
+                headers=self.connection.base_headers,
+            ),
+            timeout=timeout,
+        )
+        return response.json[1:]
 
     def get_property(self, object_type: str, object_id: int, property_name: str) -> Any:
         """Return the value of one property from one CCure object"""

--- a/acslib/ccure/crud.py
+++ b/acslib/ccure/crud.py
@@ -31,32 +31,35 @@ class CcurePersonnel(CcureACS):
 
     def search(
         self,
-        terms: Optional[list] = None,
         search_filter: Optional[PersonnelFilter] = None,
+        sort_column: str = "LastName",
+        terms: Optional[list] = None,
         page_size: Optional[int] = None,
         page_number: int = 1,
         timeout: float = 0,
         search_options: Optional[dict] = None,
         where_clause: Optional[str] = None,
+        where_arg_list: Optional[list[str]] = None,
     ) -> list:
         """
         Get a list of Personnel objects matching given search terms
 
         :param terms: list of search terms
-        :param search filter: specifies how and in what fields to look for the search terms
+        :param search_filter: specifies how and in what fields to look for the search terms
         """
         self.logger.info("Searching for personnel")
         search_filter = search_filter or self.search_filter
 
-        return super().search(
-            object_type=self.type,
-            search_filter=search_filter,
+        return super().search_personnel(
             terms=terms,
+            search_filter=search_filter,
+            sort_column=sort_column,
             page_size=page_size,
             page_number=page_number,
             timeout=timeout,
             search_options=search_options,
             where_clause=where_clause,
+            where_arg_list=where_arg_list,
         )
 
     def get_property(self, object_id: int, property_name: str) -> Any:

--- a/acslib/ccure/crud.py
+++ b/acslib/ccure/crud.py
@@ -31,9 +31,9 @@ class CcurePersonnel(CcureACS):
 
     def search(
         self,
+        terms: Optional[list] = None,
         search_filter: Optional[PersonnelFilter] = None,
         sort_column: str = "LastName",
-        terms: Optional[list] = None,
         page_size: Optional[int] = None,
         page_number: int = 1,
         timeout: float = 0,

--- a/acslib/ccure/endpoints.py
+++ b/acslib/ccure/endpoints.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 @dataclass
 class V2Endpoints:
     FIND_OBJS_W_CRITERIA = "/victorwebservice/api/Objects/FindObjsWithCriteriaFilter"
+    PERSONNEL_SEARCH = "/victorwebservice/api/v2/Personnel/PageCollection"
     PERSIST_TO_CONTAINER = "/victorwebservice/api/Objects/PersistToContainer"
     REMOVE_FROM_CONTAINER = "/victorwebservice/api/Objects/RemoveFromContainer"
     JOURNALS = "/victorWebService/api/v2/Journal/FindInJournal"

--- a/acslib/ccure/filters.py
+++ b/acslib/ccure/filters.py
@@ -96,8 +96,30 @@ class PersonnelFilter(CcureFilter):
         self.inner_bool = f" {inner_bool.value} "
         self.term_operator = term_operator.value
         self.display_properties = ["FirstName", "MiddleName", "LastName", "ObjectID"]
+        self.explicit_property_list = []
         if display_properties is not None:
             self.display_properties = display_properties
+
+    def _compile_term(self, term) -> tuple[str, list[str]]:
+        """Get all parts of the query for one search term"""
+        fields = [(field_name, lookup(term)) for field_name, lookup in self.filter_fields.items()]
+        field_queries, field_args = [], []
+        for field_name, lookup in fields:
+            field_queries.append(
+                f"{field_name} {self.term_operator} ?"
+            )
+            field_args.append(lookup)
+        return f"({self.inner_bool.join(field_queries)})", field_args
+
+    def filter(self, search: list[str]) -> tuple[str, list[str]]:
+        if not isinstance(search, list):
+            raise TypeError("Search must be a list of strings")
+        compiled_terms = [self._compile_term(term) for term in search]
+        query_string = self.outer_bool.join(compiled_term[0] for compiled_term in compiled_terms)
+        query_args = []
+        for compiled_term in compiled_terms:
+            query_args.extend(compiled_term[1])
+        return query_string, query_args
 
 
 class ClearanceFilter(CcureFilter):

--- a/acslib/ccure/filters.py
+++ b/acslib/ccure/filters.py
@@ -105,9 +105,7 @@ class PersonnelFilter(CcureFilter):
         fields = [(field_name, lookup(term)) for field_name, lookup in self.filter_fields.items()]
         field_queries, field_args = [], []
         for field_name, lookup in fields:
-            field_queries.append(
-                f"{field_name} {self.term_operator} ?"
-            )
+            field_queries.append(f"{field_name} {self.term_operator} ?")
             field_args.append(lookup)
         return f"({self.inner_bool.join(field_queries)})", field_args
 

--- a/acslib/ccure/tests/conftest.py
+++ b/acslib/ccure/tests/conftest.py
@@ -79,3 +79,9 @@ def response_w_session(base_mock_response):
 def personnel_response(response_w_session):
     response_w_session._json = {"FirstName": "Test", "MiddleName": "Ng", "LastName": "Stuff"}
     return response_w_session
+
+
+@pytest.fixture
+def clearance_response(response_w_session):
+    response_w_session._json = {"Name": "TestClearance", "ObjectID": 4000}
+    return response_w_session

--- a/acslib/ccure/tests/test_base.py
+++ b/acslib/ccure/tests/test_base.py
@@ -5,7 +5,7 @@ import pytest
 
 from acslib.ccure.base import CcureACS, CcureConnection
 from acslib.ccure import CcureAPI
-from acslib.ccure.filters import PersonnelFilter
+from acslib.ccure.filters import ClearanceFilter
 
 
 def test_default_ccure_acs(env_config, caplog):
@@ -26,13 +26,13 @@ def test_user_supplied_logger(env_config, caplog):
     assert "test:connection" in caplog.text
 
 
-def test_ccure_personnel_search(env_config, personnel_response, ccure_connection, caplog):
+def test_ccure_clearance_search(env_config, clearance_response, ccure_connection, caplog):
     ccure = CcureAPI(ccure_connection)
-    search_filter = PersonnelFilter(display_properties=["ObjectID", "FirstName"])
-    with patch("acslib.ccure.base.CcureACS.search", return_value=personnel_response) as mock_search:
-        ccure.personnel.search(terms=["test"], search_filter=search_filter)
+    search_filter = ClearanceFilter(display_properties=["ObjectID", "Name"])
+    with patch("acslib.ccure.base.CcureACS.search", return_value=clearance_response) as mock_search:
+        ccure.clearance.search(terms=["test"], search_filter=search_filter)
         mock_search.assert_called_with(
-            object_type="SoftwareHouse.NextGen.Common.SecurityObjects.Personnel",
+            object_type="SoftwareHouse.NextGen.Common.SecurityObjects.Clearance",
             search_filter=search_filter,
             terms=["test"],
             page_size=None,
@@ -41,7 +41,7 @@ def test_ccure_personnel_search(env_config, personnel_response, ccure_connection
             search_options=None,
             where_clause=None,
         )
-    assert "Searching for personnel" in caplog.text
+    assert "Searching for clearances" in caplog.text
 
 
 @pytest.mark.skip(reason="ccure search no longer works this way")

--- a/acslib/ccure/tests/test_search.py
+++ b/acslib/ccure/tests/test_search.py
@@ -54,9 +54,16 @@ def test_custom_instance():
 
 
 def test_single_search_term():
-    filter = PersonnelFilter()
+    filter = ClearanceFilter()
     search = filter.filter(["test"])
-    assert search == "(FirstName LIKE '%test%' OR LastName LIKE '%test%')"
+    assert search == "(Name LIKE '%test%')"
+
+
+def test_single_search_term_personnel():
+    filter = PersonnelFilter()
+    query_string, query_args = filter.filter(["test"])
+    assert query_string == "(FirstName LIKE ? OR LastName LIKE ?)"
+    assert query_args == ["%test%", "%test%"]
 
 
 def test_single_search_term_not_list():
@@ -66,12 +73,18 @@ def test_single_search_term_not_list():
 
 
 def test_multiple_terms():
+    filter = ClearanceFilter()
+    search = filter.filter(["test"])
+    assert search == "(Name LIKE '%test%')"
+
+
+def test_multiple_terms_personnel():
     filter = PersonnelFilter()
-    search = filter.filter(["test", "test2"])
-    assert search == (
-        "(FirstName LIKE '%test%' OR LastName LIKE '%test%') AND "
-        "(FirstName LIKE '%test2%' OR LastName LIKE '%test2%')"
+    query_string, query_args = filter.filter(["test", "test2"])
+    assert query_string == (
+        "(FirstName LIKE ? OR LastName LIKE ?) AND (FirstName LIKE ? OR LastName LIKE ?)"
     )
+    assert query_args == ["%test%", "%test%", "%test2%", "%test2%"]
 
 
 def test_update_display_properties():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "acslib"
-version = "0.1.18"
+version = "0.1.19"
 authors = [
     { name="Jeremy Gibson", email="jmgibso3@ncsu.edu" },
     { name="Luc Sanchez", email="lgsanche@ncsu.edu" },


### PR DESCRIPTION
The Personnel crud class overrides the parent search function to use a different endpoint for personnel searches. The new endpoint supports apostrophes in the search terms