### PR TITLE
Libs 45/personnel where clause

### DIFF
--- a/acslib/ccure/base.py
+++ b/acslib/ccure/base.py
@@ -81,20 +81,17 @@ class CcureACS(AccessControlSystem):
         """
         Personnel requires a separate endpoint to support searching with special characters
         """
-        is_valid_search = search_filter and terms or where_clause and where_arg_list
-        if search_filter is None and not (where_clause and where_arg_list):
-            raise ACSRequestException(400, "A search filter or where clause is required.")
-        if not terms and not (where_clause and where_arg_list):
+        is_valid_search = (terms is not None) or (where_clause and where_arg_list)
+        if not is_valid_search:
             raise ACSRequestException(
                 400,
-                "where_clause and where_arg_list are required if search terms are not included.",
+                "The where_clause and where_arg_list arguments are required "
+                "if search terms are not included.",
             )
-        if not is_valid_search:
+        if not where_clause:
             where_clause, where_arg_list = search_filter.filter(terms or [])
-        if page_size is None:
-            page_size = self.config.page_size
         request_json = {
-            "pageSize": page_size,
+            "pageSize": page_size or self.config.page_size,
             "pageNumber": page_number,
             "propertyList": search_filter.display_properties,
             "explicitPropertyList": search_filter.explicit_property_list,

--- a/acslib/ccure/base.py
+++ b/acslib/ccure/base.py
@@ -81,12 +81,18 @@ class CcureACS(AccessControlSystem):
         """
         Personnel requires a separate endpoint to support searching with special characters
         """
-        if search_filter is None and not where_clause:
+        is_valid_search = search_filter and terms or where_clause and where_arg_list
+        if search_filter is None and not (where_clause and where_arg_list):
             raise ACSRequestException(400, "A search filter or where clause is required.")
+        if not terms and not (where_clause and where_arg_list):
+            raise ACSRequestException(
+                400,
+                "where_clause and where_arg_list are required if search terms are not included.",
+            )
+        if not is_valid_search:
+            where_clause, where_arg_list = search_filter.filter(terms or [])
         if page_size is None:
             page_size = self.config.page_size
-        if not where_clause or not where_arg_list:
-            where_clause, where_arg_list = search_filter.filter(terms or [])
         request_json = {
             "pageSize": page_size,
             "pageNumber": page_number,

--- a/acslib/ccure/crud.py
+++ b/acslib/ccure/crud.py
@@ -46,6 +46,11 @@ class CcurePersonnel(CcureACS):
 
         :param terms: list of search terms
         :param search_filter: specifies how and in what fields to look for the search terms
+        :param where_clause: SQL-style where clause with values replaced with ?
+          - eg. "WHERE FirstName = ? and LastName LIKE ?"
+          - Values must be provided in the `where_arg_list` argument
+        :param where_arg_list: list of values to insert in the `where_clause` string
+          - Values must be listed in order
         """
         self.logger.info("Searching for personnel")
         search_filter = search_filter or self.search_filter

--- a/acslib/ccure/filters.py
+++ b/acslib/ccure/filters.py
@@ -109,10 +109,10 @@ class PersonnelFilter(CcureFilter):
             field_args.append(lookup)
         return f"({self.inner_bool.join(field_queries)})", field_args
 
-    def filter(self, search: list[str]) -> tuple[str, list[str]]:
-        if not isinstance(search, list):
-            raise TypeError("Search must be a list of strings")
-        compiled_terms = [self._compile_term(term) for term in search]
+    def filter(self, terms: list[str]) -> tuple[str, list[str]]:
+        if not isinstance(terms, list):
+            raise TypeError("terms must be a list of strings")
+        compiled_terms = [self._compile_term(term) for term in terms]
         query_string = self.outer_bool.join(compiled_term[0] for compiled_term in compiled_terms)
         query_args = []
         for compiled_term in compiled_terms:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "acslib"
-version = "0.1.19"
+version = "0.1.20"
 authors = [
     { name="Jeremy Gibson", email="jmgibso3@ncsu.edu" },
     { name="Luc Sanchez", email="lgsanche@ncsu.edu" },


### PR DESCRIPTION
- allow personnel search by either search terms and a filter or by where_clause and where_arg_list
- fail with a 400 if a search doesn't have all required args
- expand docstring in the search function